### PR TITLE
[feat] 로그인 api 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/open-browser.js
+++ b/open-browser.js
@@ -1,7 +1,7 @@
 const { exec } = require("child_process");
 const os = require("os");
 
-const url = "http://localhost:3000";
+const url = "https://localhost:3000";
 
 if (os.platform() === "win32") {
   exec(`start ${url}`);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run open-browser && next dev",
+    "dev": "npm run open-browser && next dev --experimental-https",
     "open-browser": "node open-browser.js",
     "build": "next build",
     "start": "next start",

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -50,17 +50,17 @@ const requestWithoutData = async <T>(
 const requestWithData = async <T>(
   url: string,
   method: string,
-  data: Record<string, unknown>,
-  options: FetcherOptions
+  data?: {}, // data가 선택적이도록 수정
+  options?: FetcherOptions
 ): Promise<FetcherResponse<T>> => {
   const fetchOptions: FetcherOptions = {
     ...options,
     method,
     headers: {
       "Content-Type": "application/json",
-      ...(options.headers || {}),
+      ...(options?.headers || {}),
     },
-    body: JSON.stringify(data),
+    ...(data ? { body: JSON.stringify(data) } : {}), // data가 있을 때만 body 추가
   };
 
   const response = await fetch(url, fetchOptions);
@@ -96,7 +96,7 @@ const createFetcher = (
       }),
     post: <T>(
       url: string,
-      data: Record<string, unknown>,
+      data?: {}, // data를 선택적으로 받도록 수정
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "POST", data, {
@@ -105,7 +105,7 @@ const createFetcher = (
       }),
     put: <T>(
       url: string,
-      data: Record<string, unknown>,
+      data: {},
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PUT", data, {
@@ -114,7 +114,7 @@ const createFetcher = (
       }),
     patch: <T>(
       url: string,
-      data: Record<string, unknown>,
+      data: {},
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PATCH", data, {

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,5 +1,5 @@
 import Routes from "@/constants/Routes";
-import { BASE_API_URL } from "@/constants/config";
+import { BASE_API_URL, CLIENT_URL } from "@/constants/config";
 import { HTTPSTATUS } from "./types";
 
 type FetcherOptions = RequestInit & {
@@ -14,7 +14,10 @@ type FetcherResponse<T> = {
 };
 
 const handleError = async (response: Response) => {
-  if (response.status === HTTPSTATUS.unAuthorized) {
+  if (
+    response.status === HTTPSTATUS.unAuthorized &&
+    typeof window !== "undefined"
+  ) {
     localStorage.removeItem("user");
     window.location.href = Routes.SIGNIN;
   }
@@ -125,6 +128,11 @@ const createFetcher = (
 };
 
 export const fetcher = createFetcher(`${BASE_API_URL}/api`, {
+  headers: { "Content-Type": "application/json" },
+  credentials: "include",
+});
+
+export const fetcherAPIRoutes = createFetcher(`${CLIENT_URL}/api`, {
   headers: { "Content-Type": "application/json" },
   credentials: "include",
 });

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -3,14 +3,30 @@ import { BASE_API_URL, CLIENT_URL } from "@/constants/config";
 import { HTTPSTATUS } from "./types";
 
 type FetcherOptions = RequestInit & {
-  next?: {
-    revalidate?: number;
-    noStore?: boolean;
-  };
+  headers?: HeadersInit;
 };
 
 type FetcherResponse<T> = {
   data: T;
+  cookies: {
+    accessToken: string | undefined;
+    refreshToken: string | undefined;
+  };
+};
+
+const getCookies = (response: Response) => {
+  const setCookieHeader = response.headers.get("set-cookie");
+
+  const cookies = setCookieHeader?.split(", ") || [];
+
+  const accessToken = cookies.find((cookie) =>
+    cookie.startsWith("accessToken")
+  );
+  const refreshToken = cookies.find((cookie) =>
+    cookie.startsWith("refreshToken")
+  );
+
+  return { accessToken, refreshToken };
 };
 
 const handleError = async (response: Response) => {
@@ -38,7 +54,6 @@ const requestWithoutData = async <T>(
       ...(options.headers || {}),
     },
   };
-
   const response = await fetch(url, fetchOptions);
 
   if (!response.ok) {
@@ -46,14 +61,15 @@ const requestWithoutData = async <T>(
   }
 
   const json = await response.json();
-  return { data: json };
+
+  return { data: json, cookies: getCookies(response) };
 };
 
 // 데이터를 받는 요청 (POST, PUT, PATCH)
 const requestWithData = async <T>(
   url: string,
   method: string,
-  data?: {}, // data가 선택적이도록 수정
+  data?: {},
   options?: FetcherOptions
 ): Promise<FetcherResponse<T>> => {
   const fetchOptions: FetcherOptions = {
@@ -63,7 +79,7 @@ const requestWithData = async <T>(
       "Content-Type": "application/json",
       ...(options?.headers || {}),
     },
-    ...(data ? { body: JSON.stringify(data) } : {}), // data가 있을 때만 body 추가
+    ...(data ? { body: JSON.stringify(data) } : {}),
   };
 
   const response = await fetch(url, fetchOptions);
@@ -73,7 +89,8 @@ const requestWithData = async <T>(
   }
 
   const json = await response.json();
-  return { data: json };
+
+  return { data: json, cookies: getCookies(response) };
 };
 
 const createFetcher = (
@@ -99,7 +116,7 @@ const createFetcher = (
       }),
     post: <T>(
       url: string,
-      data?: {}, // data를 선택적으로 받도록 수정
+      data?: {},
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "POST", data, {
@@ -127,17 +144,19 @@ const createFetcher = (
   };
 };
 
-export const fetcher = createFetcher(`${BASE_API_URL}/api`, {
-  headers: { "Content-Type": "application/json" },
+const fetcherBaseURL =
+  process.env.NODE_ENV === "development"
+    ? `${CLIENT_URL}/api/proxy`
+    : `${BASE_API_URL}/api`;
+
+export const fetcher = createFetcher(fetcherBaseURL, {
   credentials: "include",
 });
 
-export const fetcherAPIRoutes = createFetcher(`${CLIENT_URL}/api`, {
-  headers: { "Content-Type": "application/json" },
+export const proxyFetcher = createFetcher(`${BASE_API_URL}/api`, {
   credentials: "include",
 });
 
 export const fetcherWithoutCredentials = createFetcher(`${BASE_API_URL}/api`, {
-  headers: { "Content-Type": "application/json" },
   credentials: "omit",
 });

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -69,7 +69,7 @@ const requestWithoutData = async <T>(
 const requestWithData = async <T>(
   url: string,
   method: string,
-  data?: {},
+  data?: Record<string, unknown>,
   options?: FetcherOptions
 ): Promise<FetcherResponse<T>> => {
   const fetchOptions: FetcherOptions = {
@@ -116,7 +116,7 @@ const createFetcher = (
       }),
     post: <T>(
       url: string,
-      data?: {},
+      data?: Record<string, unknown>,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "POST", data, {
@@ -125,7 +125,7 @@ const createFetcher = (
       }),
     put: <T>(
       url: string,
-      data: {},
+      data: Record<string, unknown>,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PUT", data, {
@@ -134,7 +134,7 @@ const createFetcher = (
       }),
     patch: <T>(
       url: string,
-      data: {},
+      data: Record<string, unknown>,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PATCH", data, {

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -69,7 +69,7 @@ const requestWithoutData = async <T>(
 const requestWithData = async <T>(
   url: string,
   method: string,
-  data?: Record<string, unknown>,
+  data?: Record<string, unknown> | FormData,
   options?: FetcherOptions
 ): Promise<FetcherResponse<T>> => {
   const fetchOptions: FetcherOptions = {
@@ -116,7 +116,7 @@ const createFetcher = (
       }),
     post: <T>(
       url: string,
-      data?: Record<string, unknown>,
+      data?: Record<string, unknown> | FormData,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "POST", data, {
@@ -125,7 +125,7 @@ const createFetcher = (
       }),
     put: <T>(
       url: string,
-      data: Record<string, unknown>,
+      data: Record<string, unknown> | FormData,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PUT", data, {
@@ -134,7 +134,7 @@ const createFetcher = (
       }),
     patch: <T>(
       url: string,
-      data: Record<string, unknown>,
+      data: Record<string, unknown> | FormData,
       options?: FetcherOptions
     ): Promise<FetcherResponse<T>> =>
       requestWithData<T>(`${baseURL}${url}`, "PATCH", data, {

--- a/src/components/Header/desktop/HeaderTopD.tsx
+++ b/src/components/Header/desktop/HeaderTopD.tsx
@@ -6,11 +6,13 @@ import { PortfoliosDropdown } from "@/components/PortfoliosDropdown/PortfoliosDr
 import SearchBarD from "@/components/SearchBar/desktop/SearchBarD";
 import Routes from "@/constants/Routes";
 import { MAIN_HEADER_HEIGHT_D } from "@/constants/styleConstants";
+import { UserContext } from "@/features/user/context/UserContext";
 import Link from "next/link";
+import { useContext } from "react";
 import styled from "styled-components";
 
 export default function HeaderTopD() {
-  // const { user } = useContext(UserContext);
+  const { user } = useContext(UserContext);
 
   const navItems = [
     {

--- a/src/components/Header/desktop/HeaderTopD.tsx
+++ b/src/components/Header/desktop/HeaderTopD.tsx
@@ -7,12 +7,9 @@ import SearchBarD from "@/components/SearchBar/desktop/SearchBarD";
 import Routes from "@/constants/Routes";
 import { MAIN_HEADER_HEIGHT_D } from "@/constants/styleConstants";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import styled from "styled-components";
 
 export default function HeaderTopD() {
-  const router = useRouter();
-
   // const { user } = useContext(UserContext);
 
   const navItems = [
@@ -23,14 +20,6 @@ export default function HeaderTopD() {
     },
     { name: "Indices", to: Routes.INDICES("KRX:KOSPI") },
   ];
-
-  const moveToSignInPage = () => {
-    router.push(Routes.SIGNIN);
-  };
-
-  const moveToSignUpPage = () => {
-    router.push(Routes.SIGNUP);
-  };
 
   return (
     <StyledHeaderTopD>
@@ -65,12 +54,16 @@ export default function HeaderTopD() {
         )} */}
 
         <ButtonWrapper>
-          <TextButton size="h32" color="white" onClick={moveToSignInPage}>
-            로그인
-          </TextButton>
-          <Button variant="primary" size="h32" onClick={moveToSignUpPage}>
-            회원가입
-          </Button>
+          <Link href={Routes.SIGNIN}>
+            <TextButton size="h32" color="white">
+              로그인
+            </TextButton>
+          </Link>
+          <Link href={Routes.SIGNUP}>
+            <Button variant="primary" size="h32">
+              회원가입
+            </Button>
+          </Link>
         </ButtonWrapper>
       </HeaderRight>
     </StyledHeaderTopD>

--- a/src/components/Header/desktop/HeaderTopD.tsx
+++ b/src/components/Header/desktop/HeaderTopD.tsx
@@ -6,13 +6,11 @@ import { PortfoliosDropdown } from "@/components/PortfoliosDropdown/PortfoliosDr
 import SearchBarD from "@/components/SearchBar/desktop/SearchBarD";
 import Routes from "@/constants/Routes";
 import { MAIN_HEADER_HEIGHT_D } from "@/constants/styleConstants";
-import { UserContext } from "@/features/user/context/UserContext";
 import Link from "next/link";
-import { useContext } from "react";
 import styled from "styled-components";
 
 export default function HeaderTopD() {
-  const { user } = useContext(UserContext);
+  // const { user } = useContext(UserContext);
 
   const navItems = [
     {

--- a/src/components/Header/mobile/HeaderTopM.tsx
+++ b/src/components/Header/mobile/HeaderTopM.tsx
@@ -2,13 +2,15 @@ import fineantsLogo from "@/assets/icons/logo/ic_fineants_white.svg";
 import { IconButton } from "@/components/Buttons/IconButton";
 import Routes from "@/constants/Routes";
 import { MAIN_HEADER_HEIGHT_M } from "@/constants/styleConstants";
+import { UserContext } from "@/features/user/context/UserContext";
 
 import { useBoolean } from "@fineants/demolition";
 import Link from "next/link";
+import { useContext } from "react";
 import styled from "styled-components";
 
 export default function HeaderTopM() {
-  // const { user } = useContext(UserContext);
+  const { user } = useContext(UserContext);
 
   const { setTrue: onOpenSearchPanel } = useBoolean();
 

--- a/src/components/Header/mobile/HeaderTopM.tsx
+++ b/src/components/Header/mobile/HeaderTopM.tsx
@@ -2,15 +2,13 @@ import fineantsLogo from "@/assets/icons/logo/ic_fineants_white.svg";
 import { IconButton } from "@/components/Buttons/IconButton";
 import Routes from "@/constants/Routes";
 import { MAIN_HEADER_HEIGHT_M } from "@/constants/styleConstants";
-import { UserContext } from "@/features/user/context/UserContext";
 
 import { useBoolean } from "@fineants/demolition";
 import Link from "next/link";
-import { useContext } from "react";
 import styled from "styled-components";
 
 export default function HeaderTopM() {
-  const { user } = useContext(UserContext);
+  // const { user } = useContext(UserContext);
 
   const { setTrue: onOpenSearchPanel } = useBoolean();
 

--- a/src/components/PortfoliosDropdown/PortfoliosDropdown.tsx
+++ b/src/components/PortfoliosDropdown/PortfoliosDropdown.tsx
@@ -1,16 +1,17 @@
 import Routes from "@/constants/Routes";
+import { UserContext } from "@/features/user/context/UserContext";
 import { useDropdown } from "@/hooks/useDropdown";
 import designSystem, { parseFontString } from "@/styles/designSystem";
 import { useBoolean } from "@fineants/demolition";
 import Link from "next/link";
-import { MouseEvent } from "react";
+import { MouseEvent, useContext } from "react";
 import styled from "styled-components";
 import { Icon } from "../Icon";
 
 export function PortfoliosDropdown() {
   // const router = useRouter();
 
-  // const { user } = useContext(UserContext);
+  const { user } = useContext(UserContext);
 
   const { isOpen, onOpen, DropdownMenu, DropdownItem } = useDropdown();
 

--- a/src/components/PortfoliosDropdown/PortfoliosDropdown.tsx
+++ b/src/components/PortfoliosDropdown/PortfoliosDropdown.tsx
@@ -1,17 +1,16 @@
 import Routes from "@/constants/Routes";
-import { UserContext } from "@/features/user/context/UserContext";
 import { useDropdown } from "@/hooks/useDropdown";
 import designSystem, { parseFontString } from "@/styles/designSystem";
 import { useBoolean } from "@fineants/demolition";
 import Link from "next/link";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import styled from "styled-components";
 import { Icon } from "../Icon";
 
 export function PortfoliosDropdown() {
   // const router = useRouter();
 
-  const { user } = useContext(UserContext);
+  // const { user } = useContext(UserContext);
 
   const { isOpen, onOpen, DropdownMenu, DropdownItem } = useDropdown();
 

--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -1,0 +1,86 @@
+import { fetcher, fetcherWithoutCredentials } from "@/api/fetcher";
+import { Response } from "@/api/types";
+
+export type SignInCredentials = {
+  email: string;
+  password: string;
+};
+
+export type SignInData = {
+  jwt: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};
+
+export type SignUpData = {
+  [key: string]: string | File | null;
+  nickname: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+export type OAuthProvider = "google" | "naver" | "kakao";
+
+export const postSignUp = async (body: FormData) => {
+  const res = await fetcherWithoutCredentials.post<Response<null>>(
+    "/auth/signup",
+    body,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+  return res.data;
+};
+
+export const postSignIn = async (body: SignInCredentials) => {
+  const res = await fetcher.post<Response<SignInData>>("/auth/login", body);
+  return res.data;
+};
+
+export const postSignOut = async () => {
+  const res =
+    await fetcherWithoutCredentials.post<Response<null>>("/auth/logout");
+  return res.data;
+};
+
+export const postNicknameDuplicateCheck = async (nickname: string) => {
+  const res = await fetcherWithoutCredentials.get<Response<null>>(
+    `/auth/signup/duplicationcheck/nickname/${nickname}`
+  );
+  return res.data;
+};
+
+export const postEmailDuplicateCheck = async (email: string) => {
+  const res = await fetcherWithoutCredentials.get<Response<null>>(
+    `/auth/signup/duplicationcheck/email/${email}`
+  );
+  return res.data;
+};
+
+export const postEmailVerification = async (email: string) => {
+  const res = await fetcherWithoutCredentials.post<Response<null>>(
+    "/auth/signup/verifyEmail",
+    {
+      email,
+    }
+  );
+  return res.data;
+};
+
+export const postEmailCodeVerification = async ({
+  email,
+  code,
+}: {
+  email: string;
+  code: string;
+}) => {
+  const res = await fetcherWithoutCredentials.post("/auth/signup/verifyCode", {
+    email,
+    code,
+  });
+  return res.data;
+};

--- a/src/features/auth/api/queries/useEmailCodeVerificationMutation.ts
+++ b/src/features/auth/api/queries/useEmailCodeVerificationMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { postEmailCodeVerification } from "..";
+
+export default function useEmailCodeVerificationMutation() {
+  return useMutation({
+    mutationFn: (data: { email: string; code: string }) =>
+      postEmailCodeVerification(data),
+    retry: 0,
+  });
+}

--- a/src/features/auth/api/queries/useSignInMutation.ts
+++ b/src/features/auth/api/queries/useSignInMutation.ts
@@ -1,0 +1,35 @@
+import Routes from "@/constants/Routes";
+import { getUser } from "@/features/user/api";
+import { UserContext } from "@/features/user/context/UserContext";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { useContext } from "react";
+import { postSignIn } from "../index";
+
+export default function useSignInMutation() {
+  const router = useRouter();
+  const { onSignOut, onGetUser } = useContext(UserContext);
+
+  return useMutation({
+    mutationFn: postSignIn,
+    onSuccess: async () => {
+      try {
+        const {
+          data: { user },
+        } = await getUser();
+
+        onGetUser(user);
+
+        router.push(Routes.DASHBOARD);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to fetch user data");
+        onSignOut();
+        router.push(Routes.SIGNIN);
+      }
+    },
+    meta: {
+      toastErrorMessage: "이메일 또는 비밀번호가 일치하지 않습니다",
+    },
+  });
+}

--- a/src/features/auth/api/queries/useSignOutMutation.ts
+++ b/src/features/auth/api/queries/useSignOutMutation.ts
@@ -1,0 +1,22 @@
+import Routes from "@/constants/Routes";
+import { UserContext } from "@/features/user/context/UserContext";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { useContext } from "react";
+import { postSignOut } from "..";
+
+export default function useSignOutMutation() {
+  const router = useRouter();
+  const { onSignOut } = useContext(UserContext);
+
+  return useMutation({
+    mutationFn: postSignOut,
+    onSuccess: () => {
+      onSignOut();
+      router.push(Routes.LANDING);
+    },
+    meta: {
+      toastErrorMessage: "로그아웃을 다시 시도해주세요",
+    },
+  });
+}

--- a/src/features/auth/api/queries/useSignUpMutation.ts
+++ b/src/features/auth/api/queries/useSignUpMutation.ts
@@ -1,0 +1,19 @@
+import Routes from "@/constants/Routes";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { postSignUp } from "..";
+
+export default function useSignUpMutation() {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: postSignUp,
+    onSuccess: () => {
+      router.push(Routes.SIGNIN);
+    },
+    meta: {
+      toastSuccessMessage: "회원가입이 완료되었습니다",
+      toastErrorMessage: "회원가입에 실패했습니다. 다시 시도해주세요",
+    },
+  });
+}

--- a/src/features/auth/components/SignInForm.tsx
+++ b/src/features/auth/components/SignInForm.tsx
@@ -10,6 +10,7 @@ import { useText, validateEmail } from "@fineants/demolition";
 import { useRouter } from "next/router";
 import { FormEvent } from "react";
 import styled from "styled-components";
+import useSignInMutation from "../api/queries/useSignInMutation";
 import AuthPageHeader from "./AuthPageHeader";
 import SocialLoginButton from "./SocialLoginButton";
 
@@ -21,7 +22,7 @@ export default function SignInForm() {
 
   const router = useRouter();
 
-  // const { mutate: signInMutate } = useSignInMutation();
+  const { mutate: signInMutate } = useSignInMutation();
 
   const {
     value: email,
@@ -38,7 +39,7 @@ export default function SignInForm() {
 
   const onSignInSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    // signInMutate({ email, password });
+    signInMutate({ email, password });
   };
 
   const isAllFieldsFilled = !!email && !emailError && !!password;

--- a/src/features/user/api/index.ts
+++ b/src/features/user/api/index.ts
@@ -1,0 +1,40 @@
+import { fetcher } from "@/api/fetcher";
+import { Response } from "@/api/types";
+import { User } from "./types";
+
+export const getUser = async () => {
+  const res = await fetcher.get<Response<{ user: User }>>("/profile");
+  return res.data;
+};
+
+export const postProfileDetails = async (body: FormData) => {
+  const res = await fetcher.post<Response<{ user: User }>>("/profile", body, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+  return res.data;
+};
+
+export const patchUserInfo = async (body: FormData) => {
+  const res = await fetcher.patch<Response<null>>("/users/info", body, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+  return res.data;
+};
+
+export const putNewPassword = async (body: {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}) => {
+  const res = await fetcher.put<Response<null>>("/account/password", body);
+  return res.data;
+};
+
+export const deleteAccount = async () => {
+  const res = await fetcher.delete<Response<null>>("/account");
+  return res.data;
+};

--- a/src/features/user/api/queries/useAccountDeleteMutation.ts
+++ b/src/features/user/api/queries/useAccountDeleteMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+import { useContext } from "react";
+import { deleteAccount } from "..";
+import { UserContext } from "../../context/UserContext";
+
+export default function useAccountDeleteMutation() {
+  const { onSignOut } = useContext(UserContext);
+
+  return useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: onSignOut,
+    meta: {
+      toastErrorMessage: "계정 삭제를 실패했습니다",
+    },
+  });
+}

--- a/src/features/user/api/queries/usePasswordEditMutation.ts
+++ b/src/features/user/api/queries/usePasswordEditMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { putNewPassword } from "..";
+
+type Props = {
+  onSuccess: () => void;
+};
+
+export default function usePasswordEditMutation({ onSuccess }: Props) {
+  return useMutation({
+    mutationFn: putNewPassword,
+    onSuccess,
+    meta: {
+      toastSuccessMessage: "비밀번호를 변경했습니다",
+      toastErrorMessage: "비밀번호 변경을 실패했습니다",
+    },
+  });
+}

--- a/src/features/user/api/queries/useProfileDetailsMutation.ts
+++ b/src/features/user/api/queries/useProfileDetailsMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { useContext } from "react";
+import { postProfileDetails } from "..";
+import { UserContext } from "../../context/UserContext";
+
+export default function useProfileDetailsMutation() {
+  const { onEditProfileDetails } = useContext(UserContext);
+
+  return useMutation({
+    mutationFn: postProfileDetails,
+    onSuccess: (res) => {
+      onEditProfileDetails(res.data.user);
+    },
+    meta: {
+      toastSuccessMessage: "프로필 설정을 완료했습니다",
+      toastErrorMessage: "프로필 설정을 실패했습니다",
+    },
+  });
+}

--- a/src/features/user/api/types.ts
+++ b/src/features/user/api/types.ts
@@ -1,0 +1,15 @@
+import { OAuthProvider } from "@/features/auth/api";
+
+export type User = {
+  id: number;
+  nickname: string;
+  email: string;
+  profileUrl: string | null;
+  provider: OAuthProvider | "local";
+  notificationPreferences: {
+    browserNotify: boolean;
+    targetGainNotify: boolean;
+    maxLossNotify: boolean;
+    targetPriceNotify: boolean;
+  };
+};

--- a/src/features/user/context/UserContext.tsx
+++ b/src/features/user/context/UserContext.tsx
@@ -1,0 +1,78 @@
+import { ReactNode, createContext, useState } from "react";
+import { User } from "../api/types";
+
+export const UserContext = createContext<{
+  user: User | null;
+  fcmTokenId: number | null;
+  onSignOut: () => void;
+  onGetUser: (user: User) => void;
+  onEditProfileDetails: (user: User) => void;
+  onSubscribePushNotification: (fcmTokenId: number) => void;
+  onUnsubscribePushNotification: () => void;
+}>({
+  user: null,
+  fcmTokenId: null,
+  onSignOut: () => {},
+  onGetUser: () => {},
+  onEditProfileDetails: () => {},
+  onSubscribePushNotification: () => {},
+  onUnsubscribePushNotification: () => {},
+});
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const getUser = () => {
+    if (typeof window !== "undefined") {
+      const storedUser = localStorage.getItem("user");
+      return storedUser ? JSON.parse(storedUser) : null;
+    }
+    return null;
+  };
+
+  const [user, setUser] = useState<User | null>(getUser());
+  const [fcmTokenId, setFcmTokenId] = useState<number | null>(null);
+
+  const onSignOut = () => {
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("user");
+    }
+    setUser(null);
+  };
+
+  const onGetUser = (user: User) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("user", JSON.stringify(user));
+      localStorage.setItem("recentLoginMethod", user.provider);
+    }
+    setUser(user);
+  };
+
+  const onEditProfileDetails = (user: User) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("user", JSON.stringify(user));
+    }
+    setUser(user);
+  };
+
+  const onSubscribePushNotification = async (fcmTokenId: number) => {
+    setFcmTokenId(fcmTokenId);
+  };
+
+  const onUnsubscribePushNotification = async () => {
+    setFcmTokenId(null);
+  };
+
+  return (
+    <UserContext.Provider
+      value={{
+        user,
+        fcmTokenId,
+        onSignOut,
+        onGetUser,
+        onEditProfileDetails,
+        onSubscribePushNotification,
+        onUnsubscribePushNotification,
+      }}>
+      {children}
+    </UserContext.Provider>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { UserProvider } from "@/features/user/context/UserContext";
 import GlobalStyles from "@/styles/GlobalStyles";
 import { AppCacheProvider } from "@mui/material-nextjs/v13-pagesRouter";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -64,12 +65,14 @@ const queryClient = new QueryClient({
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
-      <AppCacheProvider>
-        <main className={ibmPlexSansKR.className}>
-          <GlobalStyles />
-          <Component {...pageProps} class />
-        </main>
-      </AppCacheProvider>
+      <UserProvider>
+        <AppCacheProvider>
+          <main className={ibmPlexSansKR.className}>
+            <GlobalStyles />
+            <Component {...pageProps} class />
+          </main>
+        </AppCacheProvider>
+      </UserProvider>
     </QueryClientProvider>
   );
 }

--- a/src/pages/api/proxy/auth/login.ts
+++ b/src/pages/api/proxy/auth/login.ts
@@ -47,7 +47,6 @@ export default async function handler(
 
       return res.status(200).json(data);
     } catch (error) {
-      console.error("Error during login:", error);
       return res.status(500).json({ error: "Internal server error" });
     }
   } else {

--- a/src/pages/api/proxy/auth/login.ts
+++ b/src/pages/api/proxy/auth/login.ts
@@ -1,0 +1,57 @@
+import { proxyFetcher } from "@/api/fetcher";
+import { Response } from "@/api/types";
+import { SignInData } from "@/features/auth/api";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const replaceCookieDomain = (cookieStr: string, newDomain: string) => {
+  const cookieParts = cookieStr.split(";");
+  const updatedCookieParts = cookieParts.map((part) => {
+    if (part.trim().startsWith("Domain=")) {
+      return ` Domain=${newDomain}`;
+    }
+    return part;
+  });
+  return updatedCookieParts.join(";");
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === "POST") {
+    try {
+      const cookies = req.cookies;
+      const cookieString = Object.entries(cookies)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("; ");
+
+      const { data, cookies: { accessToken, refreshToken } = {} } =
+        await proxyFetcher.post<Response<SignInData>>("/auth/login", req.body, {
+          headers: {
+            Cookie: cookieString || "",
+          },
+        });
+
+      if (accessToken && refreshToken) {
+        const updatedAccessToken = replaceCookieDomain(
+          accessToken,
+          "localhost"
+        );
+        const updatedRefreshToken = replaceCookieDomain(
+          refreshToken,
+          "localhost"
+        );
+
+        res.setHeader("Set-Cookie", [updatedAccessToken, updatedRefreshToken]);
+      }
+
+      return res.status(200).json(data);
+    } catch (error) {
+      console.error("Error during login:", error);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  } else {
+    res.setHeader("Allow", ["POST"]);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/src/pages/api/proxy/profile.ts
+++ b/src/pages/api/proxy/profile.ts
@@ -47,7 +47,6 @@ export default async function handler(
 
       return res.status(200).json(data);
     } catch (error) {
-      console.error("Error fetching user profile:", error);
       return res.status(500).json({ error: "Internal server error" });
     }
   } else {

--- a/src/pages/api/proxy/profile.ts
+++ b/src/pages/api/proxy/profile.ts
@@ -1,0 +1,57 @@
+import { proxyFetcher } from "@/api/fetcher";
+import { Response } from "@/api/types";
+import { User } from "@/features/user/api/types";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const replaceCookieDomain = (cookieStr: string, newDomain: string) => {
+  const cookieParts = cookieStr.split(";");
+  const updatedCookieParts = cookieParts.map((part) => {
+    if (part.trim().startsWith("Domain=")) {
+      return ` Domain=${newDomain}`;
+    }
+    return part;
+  });
+  return updatedCookieParts.join(";");
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === "GET") {
+    try {
+      const cookies = req.cookies;
+      const cookieString = Object.entries(cookies)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("; ");
+
+      const { data, cookies: { accessToken, refreshToken } = {} } =
+        await proxyFetcher.get<Response<{ user: User }>>("/profile", {
+          headers: {
+            Cookie: cookieString || "",
+          },
+        });
+
+      if (accessToken && refreshToken) {
+        const updatedAccessToken = replaceCookieDomain(
+          accessToken,
+          "localhost"
+        );
+        const updatedRefreshToken = replaceCookieDomain(
+          refreshToken,
+          "localhost"
+        );
+
+        res.setHeader("Set-Cookie", [updatedAccessToken, updatedRefreshToken]);
+      }
+
+      return res.status(200).json(data);
+    } catch (error) {
+      console.error("Error fetching user profile:", error);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  } else {
+    res.setHeader("Allow", ["GET"]);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>대시보드</div>;
+}


### PR DESCRIPTION
## 구현한 것
- #10 


## 문제 사항
- 프론트엔드 local에서 실행시 배포된 백엔드에게 받는 cookie가 nextjs 클라이언트 -> nextjs 서버로부터 전달이 안되는 문제

### 이유
- 배포된 백엔드 서버로부터 받는 cookie의 도메인은 `.fineants.co` 하지만 nextjs 클라이언트가 보내는 nextjs 서버의 도메인은 `.fineants.co`에 포함되지 않아서 cookie를 전달하지 않는 문제

### 해결
- env 값을 확인하여 product와 dev 상태를 확인하여 dev인 경우 모든 api 요청을 proxy처럼 api route를 통해서 다시 백엔드 서버로 전달하는 방식을 사용
- 이 과정에서 로그인의 경우 백엔드로부터 받은 쿠키를 도메인 localhost로 다시 브라우저에 set해줌
- dev 환경에서는 도메인 localhost로 받은 cookie를 활용

### 추가 해결해야하는 부분
- proxy 처럼 api route를 사용해야하다 보니 모든 api에 맞는 api route를 모두 추가해야하는 불편함이 있음.
- code generator를 구현해서 api 파일을 파싱해서 /api/proxy  경로에 api route의 생성을 자동화할 수 있지 않을까 라는 생각중
- 또 product에서 /api/proxy 경로의 파일은 필요 없으니 빌드에서 제외해야 할 것 같음
