### PR TITLE
[reafctor] Proxy api router 동일 경로 api 대응 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,13 @@
   "rules": {
     "no-console": "error",
     "react/no-unescaped-entities": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": ["scripts/**/*.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/scripts/utils/api-router-generator-utils.ts
+++ b/scripts/utils/api-router-generator-utils.ts
@@ -34,7 +34,7 @@ const createApiFiles = (methodDetails: MethodDetails[]) => {
       .filter((part) => part !== "")
       .map((part) => (part.startsWith("${") ? `[${part.slice(2, -1)}]` : part));
 
-    const filePath = path.join("./src/pages/api/proxy", ...urlParts) + `.ts`;
+    const filePath = path.join("./src/pages/api/proxy", ...urlParts) + ".ts";
 
     // 파일 디렉토리 없을 경우 생성
     const dirPath = path.dirname(filePath);
@@ -54,7 +54,7 @@ const createApiFiles = (methodDetails: MethodDetails[]) => {
     const methodHandlers = methods
       .map((method) => {
         const hasBody = ["POST", "PUT", "PATCH"].includes(method);
-        const bodyContent = hasBody ? `, req.body` : ``;
+        const bodyContent = hasBody ? ", req.body" : "";
 
         return `
       case "${method}":

--- a/scripts/utils/api-router-generator-utils.ts
+++ b/scripts/utils/api-router-generator-utils.ts
@@ -18,15 +18,23 @@ export const generateApiRouter = (filePath: string) => {
 
 // 파일 생성 함수
 const createApiFiles = (methodDetails: MethodDetails[]) => {
-  methodDetails.forEach(({ url, httpMethod }) => {
-    if (!url || !httpMethod) return;
+  const groupedByRoute = methodDetails.reduce(
+    (acc, { url, httpMethod }) => {
+      if (!url || !httpMethod) return acc;
+      if (!acc[url]) acc[url] = [];
+      acc[url].push(httpMethod);
+      return acc;
+    },
+    {} as Record<string, string[]>
+  );
 
+  Object.entries(groupedByRoute).forEach(([url, methods]) => {
     const urlParts = url
       .split("/")
       .filter((part) => part !== "")
       .map((part) => (part.startsWith("${") ? `[${part.slice(2, -1)}]` : part));
 
-    const filePath = path.join("./src/pages/api/proxy", ...urlParts) + ".ts";
+    const filePath = path.join("./src/pages/api/proxy", ...urlParts) + `.ts`;
 
     // 파일 디렉토리 없을 경우 생성
     const dirPath = path.dirname(filePath);
@@ -42,8 +50,45 @@ const createApiFiles = (methodDetails: MethodDetails[]) => {
           .join("\n")
       : "";
 
-    const hasBody = ["POST", "PUT", "PATCH"].includes(httpMethod);
-    const bodyContent = hasBody ? `, req.body` : ``;
+    // Method 별 처리
+    const methodHandlers = methods
+      .map((method) => {
+        const hasBody = ["POST", "PUT", "PATCH"].includes(method);
+        const bodyContent = hasBody ? `, req.body` : ``;
+
+        return `
+      case "${method}":
+        try {
+          const { data, cookies: { accessToken, refreshToken } = {} } =
+            await proxyFetcher.${method.toLowerCase()}<Response<unknown>>(\`${url.replace(
+              /\$\{(\w+)\}/g,
+              (_, variable) => `\${${variable}}`
+            )}\`${bodyContent}, {
+              headers: {
+                Cookie: cookieString || "",
+              },
+            });
+
+          if (accessToken && refreshToken) {
+            const updatedAccessToken = replaceCookieDomain(
+              accessToken,
+              "localhost"
+            );
+            const updatedRefreshToken = replaceCookieDomain(
+              refreshToken,
+              "localhost"
+            );
+
+            res.setHeader("Set-Cookie", [updatedAccessToken, updatedRefreshToken]);
+          }
+
+          return res.status(200).json(data);
+        } catch (error) {
+          return res.status(500).json({ error: "Internal server error" });
+        }
+      `;
+      })
+      .join("\n");
 
     // 템플릿 코드
     const template = `import { proxyFetcher } from "@/api/fetcher";
@@ -51,45 +96,18 @@ import { Response } from "@/api/types";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === "${httpMethod}") {
-    try {
-      const cookies = req.cookies;
-      const cookieString = Object.entries(cookies)
-        .map(([key, value]) => \`\${key}=\${value}\`)
-        .join("; ");
+  const cookies = req.cookies;
+  const cookieString = Object.entries(cookies)
+    .map(([key, value]) => \`\${key}=\${value}\`)
+    .join("; ");
 
-      ${queryExtract}
+  ${queryExtract}
 
-      const { data, cookies: { accessToken, refreshToken } = {} } =
-        await proxyFetcher.${httpMethod.toLowerCase()}<Response<unknown>>(\`${url.replace(
-          /\$\{(\w+)\}/g,
-          (_, variable) => `\${${variable}}`
-        )}\`${bodyContent}, {
-          headers: {
-            Cookie: cookieString || "",
-          },
-        });
-
-      if (accessToken && refreshToken) {
-        const updatedAccessToken = replaceCookieDomain(
-          accessToken,
-          "localhost"
-        );
-        const updatedRefreshToken = replaceCookieDomain(
-          refreshToken,
-          "localhost"
-        );
-
-        res.setHeader("Set-Cookie", [updatedAccessToken, updatedRefreshToken]);
-      }
-
-      return res.status(200).json(data);
-    } catch (error) {
-      return res.status(500).json({ error: "Internal server error" });
-    }
-  } else {
-    res.setHeader("Allow", ["${httpMethod}"]);
-    res.status(405).end(\`Method \${req.method} Not Allowed\`);
+  switch (req.method) {
+    ${methodHandlers}
+    default:
+      res.setHeader("Allow", [${methods.map((m) => `"${m}"`).join(", ")}]);
+      res.status(405).end(\`Method \${req.method} Not Allowed\`);
   }
 }
 


### PR DESCRIPTION
## 구현한 것
- #20
- script 경로에 console.log eslint 경고 해제

## 문제 상황
- /profile get 요청과 /profile post 요청으로 2가지 api가 있다.
- 이때 기존 Code generator에서는 url 경로에 맞는 profile이라는 하나의 파일에 하나의 요청만 들고 있다.
- 즉, /profile get 요청의 내용을 만들었어도 뒤에 오는 /profile post 요청의 api router로 덮어쓰기가 되고 있었다.
- **그래서 이 문제를 해결하기 위해서 동일 url에 맞는 요청을 만들도록 수정**
